### PR TITLE
Export a variable to set GCP service account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ module "main" {
   version = "23.1.0"
 
   cluster_resource_labels    = var.tags
+  create_service_account     = var.gcp_service_account == "" ? true : false
   ip_range_pods              = var.pod_cidr_name
   ip_range_services          = var.service_cidr_name
   horizontal_pod_autoscaling = true
@@ -48,6 +49,7 @@ module "main" {
       min_count          = node_pool.min_nodes
       name               = key
       preemptible        = node_pool.preemptible
+      service_account    = var.gcp_service_account
     }
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "pod_cidr_name" {
   type        = string
 }
 
+variable "gcp_service_account" {
+  description = "The GCP service account to use when running nodes. If empty, a new one will be created automatically."
+  type        = string
+  default     = ""
+}
+
 variable "service_cidr_name" {
   description = "The name of the secondary CIDR used for services. Must be created separately as a secondary CIDR on the subnet used for the cluster."
   type        = string


### PR DESCRIPTION
By default a new service account is created to run nodes for the GKE cluster, and this account must have the IAM role `logging.logWriter` to operate correctly.

To simplify the role management when the module is used from a GH Action, the variable `create_service_account` is exposed, in order to force the use of the same service account configured in the Action.

Doing so, it is sufficient to configure that single Service Account with the correct IAM Role.